### PR TITLE
apps start on build-start on open is TODO

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,11 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x -o /tmp/nodesource_setup.sh &
 
 RUN pip install pre-commit
 
+COPY postCreateCommand.sh .
+
+CMD ["./postCreateCommand"]
+
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,8 +15,18 @@
       "label": "Application"
     }
   },
+  
   "customizations": {
     "vscode": {
+      //TODO
+      /** 
+      "settings": {
+        "terminal.integrated.shellArgs.linux": [
+          "-c",
+          "cd /workspace/.devcontainer/start-dev.sh/directory && ./start-dev.sh; exec $SHELL"
+        ]
+      },
+      **/
       "extensions": [
         "ms-vscode-remote.remote-containers",
         "esbenp.prettier-vscode",
@@ -28,4 +38,5 @@
       ]
     }
   }
+  
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,8 +1,31 @@
 pre-commit install
 
+terminate_processes() {
+  echo "Terminating dotnet and yarn processes..."
+  kill $dotnet_pid
+  kill $yarn_pid
+  exit 0
+}
+
+# Trap for term
+trap terminate_processes SIGINT SIGTERM
+
+#run api
 cd server
 dotnet restore
 dotnet dev-certs https --trust
+dotnet run &
 
+#save the background process id
+dotnet_pid=$!
+
+#run web app
 cd ../client
-yarn
+yarn run dev &
+
+#save the background process id
+yarn_pid=$!
+
+
+wait $dotnet_pid
+wait $yarn_pid

--- a/.devcontainer/start-dev.sh
+++ b/.devcontainer/start-dev.sh
@@ -1,0 +1,46 @@
+start_dotnet_server() {
+  if ! pgrep -f "dotnet run --urls=http://*:8080"; then
+    echo "Starting dotnet server..."
+    cd /workspace/server
+    dotnet restore
+    dotnet dev-certs https --trust &
+    dotnet_pid=$!
+    
+  else
+    echo "Dotnet server is already running."
+  fi
+}
+
+# Function to start the React app if it's not running
+start_react_app() {
+  if ! pgrep -f "yarn start"; then
+    echo "Starting React app..."
+    cd ../workspace/app
+    yarn start &
+    yarn_pid=$!
+  else
+    echo "React app is already running."
+  fi
+}
+
+# Function to terminate both processes on receiving termination signals
+terminate_processes() {
+  echo "Terminating dotnet and yarn processes..."
+  kill $dotnet_pid
+  kill $yarn_pid
+  exit 0
+}
+
+
+
+# Call the functions to start the apps if they are not running
+start_dotnet_server
+start_react_app
+
+trap terminate_processes SIGINT SIGTERM
+# Wait for both processes to complete
+wait $dotnet_pid
+wait $yarn_pid
+
+# Keep the terminal session active
+exec "$@"


### PR DESCRIPTION
On build both apps launch
-- put processes in background
-- couldn't quite figure out the configuration for the shell to have startup script when a new terminal is opened so it currently only launches the apps after building the container. Left the script in there if anyone wants to pick it up in the meantime. 